### PR TITLE
Update version to 8.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.3.1" %}
+{% set version = "8.6.0" %}
 
 {% set base_url = "https://github.com/bazelbuild/bazel/releases/download" %}
 
@@ -8,7 +8,7 @@ package:
 
 source:
   - url: {{ base_url }}/{{ version }}/bazel-{{ version }}-dist.zip
-    sha256: 79da863df05fa4de79a82c4f9d4e710766f040bc519fd8b184a4d4d51345d5ba
+    sha256: 13a84586429b6084b13bd5040d78deda58d523012151e71e7d4be0c63dd831f9
 
   - fn: bazel
     url: {{ base_url }}/{{ version }}/bazel_nojdk-{{ version }}-linux-x86_64  # [build_platform == "linux-64"]
@@ -16,7 +16,7 @@ source:
     url: {{ base_url }}/{{ version }}/bazel_nojdk-{{ version }}-linux-arm64   # [build_platform == "linux-aarch64"]
     sha256: 57d6bc110053c7926b6e0acc5dff2d5eea9d4b59ad4c180ce2bbff84759b6c1b  # [build_platform == "linux-aarch64"]
     url: {{ base_url }}/{{ version }}/bazel_nojdk-{{ version }}-darwin-arm64  # [build_platform == "osx-arm64"]
-    sha256: 08a3a9919b60e7925597f5c136ef58ff56ca0864e1b15557dd3e659dc5739280  # [build_platform == "osx-arm64"]
+    sha256: 61776a387f2ea2a515eb92bc1c520b6af6451148216244058f6ee2b4c012cd89  # [build_platform == "osx-arm64"]
 
 build:
   number: 0
@@ -27,7 +27,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
-    - bazel-toolchain >=0.2.0
+    - bazel-toolchain >=0.2.0,<0.5.0
     - openjdk
     - sed
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,9 @@ source:
 
   - fn: bazel
     url: {{ base_url }}/{{ version }}/bazel_nojdk-{{ version }}-linux-x86_64  # [build_platform == "linux-64"]
-    sha256: 6b238b730c63081aed681dd2818072f73551881c0cc7976ebfb749a4aa8097fe  # [build_platform == "linux-64"]
+    sha256: 02c355741012603b703e2a8d07ded1212f92ec6eacdabdd552695f8083e7a594  # [build_platform == "linux-64"]
     url: {{ base_url }}/{{ version }}/bazel_nojdk-{{ version }}-linux-arm64   # [build_platform == "linux-aarch64"]
-    sha256: 57d6bc110053c7926b6e0acc5dff2d5eea9d4b59ad4c180ce2bbff84759b6c1b  # [build_platform == "linux-aarch64"]
+    sha256: 19b9c2f6dbb87d9d9c64a951e01b9e62abe8b8ea07550206609c62b7f0f12ae9  # [build_platform == "linux-aarch64"]
     url: {{ base_url }}/{{ version }}/bazel_nojdk-{{ version }}-darwin-arm64  # [build_platform == "osx-arm64"]
     sha256: 61776a387f2ea2a515eb92bc1c520b6af6451148216244058f6ee2b4c012cd89  # [build_platform == "osx-arm64"]
 


### PR DESCRIPTION
ijar 8.6.0

**Destination channel:**  defaults

### Links

- [PKG-12903](https://anaconda.atlassian.net/browse/PKG-12903) 
- [Upstream repository](https://github.com/bazelbuild/bazel/tree/8.6.0)

### Explanation of changes:
- New version number


[PKG-12903]: https://anaconda.atlassian.net/browse/PKG-12903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ